### PR TITLE
Clear environment variable ERL_FLAGS before obtaining the erlang version

### DIFF
--- a/priv/templates/concrete_project_concrete.mk
+++ b/priv/templates/concrete_project_concrete.mk
@@ -87,7 +87,7 @@ PROJ = $(notdir $(CURDIR))
 
 # Let's compute $(BASE_PLT_ID) that identifies the base PLT to use for this project
 # and depends on your `$(ERLANG_DIALYZER_APPS)' list and your erlang version
-ERLANG_VERSION := $(shell $(ERL) -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().' -noshell)
+ERLANG_VERSION := $(shell ERL_FLAGS="" $(ERL) -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().' -noshell)
 MD5_BIN := $(shell which md5 || which md5sum)
 ifeq ($(MD5_BIN),)
 # neither md5 nor md5sum, we just take the project name


### PR DESCRIPTION
In cases where the name of a running node is set through the environment variable ERL_FLAGS (e.q. ERL_FLAGS="-sname test"), the command to fetch the erlang version will try to start a node with the same configs and fail. A local clear of ERL_FLAGS for that command will prevent this behavior.